### PR TITLE
Use hourly endpoint for NASA POWER data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # nasa-power-api
 Download meteorological data records from Nasa Power.
 
-You will receive data on:
+You will receive hourly data on:
 
 - Temperature (Temperature at 2 Meters, Wet Bulb Temperature at 2 Meters, etc.)
 - Humidity/Precipitation (Specific Humidity at 2 Meters, Relative Humidity at 2 Meters, Precipitation)
@@ -11,17 +11,17 @@ You can find a detailed list of all available parameters at: https://power.larc.
 
 ### Usage Instructions
 
-Simply edit the config.yaml by specifying your latitude, longitude, start date, and end date values.
+Simply edit the config.yaml by specifying your latitude, longitude, start time, and end time values.
 
     # Location
     lat: 53.524960
     lon: -1.627447
 
-    # Format: YYYYMMDD
-    # Earliest is 19810101
-    start_date: 20100301
+    # Format: YYYYMMDDHH
+    # Earliest is 1981010100
+    start_time: 2010030100
 
-    # Format: YYYYMMDD
-    end_date: 20210101
+    # Format: YYYYMMDDHH
+    end_time: 2010030123
 
 Hit run to save the respective .csv file in the project's data directory.

--- a/config.yaml
+++ b/config.yaml
@@ -5,11 +5,11 @@
 lat: 53.524960
 lon: -1.627447
 
-# Format: YYYYMMDD
-start_date: 20000101
+# Format: YYYYMMDDHH
+start_time: 2000010100
 
-# Format: YYYYMMDD
-end_date: 20210101
+# Format: YYYYMMDDHH
+end_time: 2000010123
 
 # Output directory for weather records
 output_dir: ./data

--- a/main.py
+++ b/main.py
@@ -15,13 +15,13 @@ def main():
 
     latitude = conf.get('lat', 0)
     longitude = conf.get('lon', 0)
-    start_date = conf.get('start_date', 0)
-    end_date = conf.get('end_date', 0)
+    start_time = conf.get('start_time', 0)
+    end_time = conf.get('end_time', 0)
     output_dir = conf.get('output_dir', 0)
 
     output_dir = Path(output_dir) / f"{longitude};{latitude}.csv"
 
-    nasa_weather = PowerAPI(start=pd.Timestamp(str(start_date)), end=pd.Timestamp(str(end_date)), long=longitude, lat=latitude)
+    nasa_weather = PowerAPI(start=pd.Timestamp(str(start_time)), end=pd.Timestamp(str(end_time)), long=longitude, lat=latitude)
 
     weather_df = nasa_weather.get_weather()
 

--- a/src/power_api.py
+++ b/src/power_api.py
@@ -18,7 +18,7 @@ class PowerAPI:
     url : str
         Base URL
     """
-    url = "https://power.larc.nasa.gov/api/temporal/daily/point?"
+    url = "https://power.larc.nasa.gov/api/temporal/hourly/point?"
 
     def __init__(self,
                  start: Union[date, datetime, pd.Timestamp],
@@ -30,7 +30,9 @@ class PowerAPI:
         Parameters
         ----------
         start: Union[date, datetime, pd.Timestamp]
+            Start time. Hour resolution is supported.
         end: Union[date, datetime, pd.Timestamp]
+            End time. Hour resolution is supported.
         long: float
             Longitude as float
         lat: float
@@ -40,9 +42,8 @@ class PowerAPI:
             the data with the latter
         parameter: Optional[List[str]]
             List with the parameters to query.
-            Default is ['T2M_RANGE', 'TS', 'T2MDEW', 'T2MWET', 'T2M_MAX', 'T2M_MIN', 'T2M', 'QV2M', 'RH2M',
-                        'PRECTOTCORR', 'PS', 'WS10M', 'WS10M_MAX', 'WS10M_MIN', 'WS10M_RANGE', 'WS50M', 'WS50M_MAX',
-                        'WS50M_MIN', 'WS50M_RANGE']
+            Default is ['T2M', 'TS', 'T2MDEW', 'T2MWET', 'QV2M', 'RH2M',
+                        'PRECTOTCORR', 'PS', 'WS10M', 'WS50M']
         """
         self.start = start
         self.end = end
@@ -50,9 +51,8 @@ class PowerAPI:
         self.lat = lat
         self.use_long_names = use_long_names
         if parameter is None:
-            self.parameter = ['T2M_RANGE', 'TS', 'T2MDEW', 'T2MWET', 'T2M_MAX', 'T2M_MIN', 'T2M', 'QV2M', 'RH2M',
-                              'PRECTOTCORR', 'PS', 'WS10M', 'WS10M_MAX', 'WS10M_MIN', 'WS10M_RANGE', 'WS50M', 'WS50M_MAX',
-                              'WS50M_MIN', 'WS50M_RANGE']
+            self.parameter = ['T2M', 'TS', 'T2MDEW', 'T2MWET', 'QV2M', 'RH2M',
+                              'PRECTOTCORR', 'PS', 'WS10M', 'WS50M']
 
         self.request = self._build_request()
 
@@ -69,8 +69,8 @@ class PowerAPI:
         r += '&community=RE'
         r += f"&longitude={self.long}"
         r += f"&latitude={self.lat}"
-        r += f"&start={self.start.strftime('%Y%m%d')}"
-        r += f"&end={self.end.strftime('%Y%m%d')}"
+        r += f"&start={self.start.strftime('%Y%m%d%H')}"
+        r += f"&end={self.end.strftime('%Y%m%d%H')}"
         r += '&format=JSON'
 
         return r


### PR DESCRIPTION
## Summary
- Switch API URL to hourly NASA POWER endpoint and add hour resolution handling
- Rename configuration keys to `start_time`/`end_time` and document hourly format
- Trim default parameter list to hourly-compatible variables

## Testing
- `python main.py` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pip install pyyaml` *(fails: Could not find a version that satisfies the requirement pyyaml)*
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68ac87e6427c83249f2b57a19289dd10